### PR TITLE
Fix request with multiple scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Please see [CONTRIBUTING](https://github.com/stevenmaguire/oauth2-keycloak/blob/
 ## Credits
 
 - [Steven Maguire](https://github.com/stevenmaguire)
+- [Martin Stefan](https://github.com/mstefan21)
 - [All Contributors](https://github.com/stevenmaguire/oauth2-keycloak/contributors)
 
 

--- a/src/Provider/Keycloak.php
+++ b/src/Provider/Keycloak.php
@@ -174,7 +174,7 @@ class Keycloak extends AbstractProvider
      */
     protected function getDefaultScopes()
     {
-        return ['name', 'email'];
+        return ['profile', 'email'];
     }
 
     /**

--- a/src/Provider/Keycloak.php
+++ b/src/Provider/Keycloak.php
@@ -178,6 +178,18 @@ class Keycloak extends AbstractProvider
     }
 
     /**
+     * Returns the string that should be used to separate scopes when building
+     * the URL for requesting an access token.
+     *
+     * @return string Scope separator, defaults to ','
+     */
+    protected function getScopeSeparator()
+    {
+        return ' ';
+    }
+
+
+    /**
      * Check a provider response for errors.
      *
      * @throws IdentityProviderException


### PR DESCRIPTION
PR avec les nouveaux commits du repo upstream, et notamment un pour gérer les requests avec plusieurs scopes. Ca sera utile pour R2. Le problème venait du séparateur entre les scopes, qui ne doit pas être une virgule mais un espace avec Keycloak.